### PR TITLE
Refactors TileEntity to use a list of ItemStacks

### DIFF
--- a/src/main/java/com/mowmaster/rprocessing/blocks/BlockClayBloomery.java
+++ b/src/main/java/com/mowmaster/rprocessing/blocks/BlockClayBloomery.java
@@ -84,7 +84,7 @@ public class BlockClayBloomery extends Block implements ITileEntityProvider
                 if((playerIn.getHeldItem(hand) != null))
                 {
                     if(ItemStack.areItemsEqual(playerIn.getHeldItem(hand), new ItemStack(Blocks.IRON_ORE))) {
-                        if(bloom.addIron())
+                        if(bloom.addOre(new ItemStack(Blocks.IRON_ORE)))
                         {
                             //playerIn.sendMessage(new TextComponentString("You are adding Iron Ore"));
                             playerIn.sendStatusMessage(new TextComponentString(TextFormatting.GRAY +"You are adding Iron Ore"),true);
@@ -94,30 +94,22 @@ public class BlockClayBloomery extends Block implements ITileEntityProvider
                 }
                 if(playerIn.isSneaking())
                 {
-                    if(bloom.removeIron())
+                    if(bloom.removeOre())
                     {
                         //playerIn.sendMessage(new TextComponentString("You are removing Iron Ore"));
-                        playerIn.sendStatusMessage(new TextComponentString(TextFormatting.GRAY +"You are removing Iron Ore"),true);
+                        playerIn.sendStatusMessage(new TextComponentString(TextFormatting.GRAY +"You are removing Ore"),true);
                     }
                 }
 
                 if((playerIn.getHeldItem(hand) != null))
                 {
                     if(ItemStack.areItemsEqual(playerIn.getHeldItem(hand), new ItemStack(Blocks.GOLD_ORE))) {
-                        if(bloom.addGold())
+                        if(bloom.addOre(new ItemStack(Blocks.GOLD_ORE)))
                         {
                             //playerIn.sendMessage(new TextComponentString("You are adding Gold Ore"));
                             playerIn.sendStatusMessage(new TextComponentString(TextFormatting.GOLD +"You are adding Gold Ore"),true);
                             playerIn.getHeldItem(hand).shrink(1);
                         }
-                    }
-                }
-                if(playerIn.isSneaking())
-                {
-                    if(bloom.removeGold())
-                    {
-                        //playerIn.sendMessage(new TextComponentString("You are removing Gold Ore"));
-                        playerIn.sendStatusMessage(new TextComponentString(TextFormatting.GOLD +"You are removing Gold Ore"),true);
                     }
                 }
 

--- a/src/main/java/com/mowmaster/rprocessing/tiles/render/RenderTileClayBloomery.java
+++ b/src/main/java/com/mowmaster/rprocessing/tiles/render/RenderTileClayBloomery.java
@@ -49,11 +49,13 @@ public class RenderTileClayBloomery extends TileEntitySpecialRenderer<TileClayBl
             GlStateManager.enableAlpha();
             GlStateManager.enableBlend();
             GlStateManager.enableLighting();
-            for(int j=0;j<te.oreiron && j<4;j++)
+            for(int j=0; j<te.orelist.size() && j < 4;j++)
             {
                 //Minecraft.getMinecraft().getRenderManager().doRenderEntity(IRON,0,0,0,0f,0f,false);
-                Minecraft.getMinecraft().getRenderItem().renderItem(new ItemStack(Blocks.IRON_ORE), ItemCameraTransforms.TransformType.GROUND);
+                Minecraft.getMinecraft().getRenderItem().renderItem(te.orelist.get(j).copy(), ItemCameraTransforms.TransformType.GROUND);
                 GlStateManager.translate(0,0.2,0);
+                GlStateManager.rotate(45f + j*10,0,1,0);
+
             }
         }
         GlStateManager.popMatrix();
@@ -67,49 +69,12 @@ public class RenderTileClayBloomery extends TileEntitySpecialRenderer<TileClayBl
             GlStateManager.enableAlpha();
             GlStateManager.enableBlend();
             GlStateManager.enableLighting();
-            for(int j=4;j<te.oreiron && j>=4;j++)
+            for(int j=4;j<te.orelist.size();j++)
             {
                 //Minecraft.getMinecraft().getRenderManager().doRenderEntity(IRON,0,0,0,0f,0f,false);
-                Minecraft.getMinecraft().getRenderItem().renderItem(new ItemStack(Blocks.IRON_ORE), ItemCameraTransforms.TransformType.GROUND);
+                Minecraft.getMinecraft().getRenderItem().renderItem(te.orelist.get(j).copy(), ItemCameraTransforms.TransformType.GROUND);
                 GlStateManager.translate(0,0.2,0);
-            }
-        }
-        GlStateManager.popMatrix();
-        {}
-
-
-        GlStateManager.pushMatrix();
-        {
-            GlStateManager.translate(x,y,z);
-            GlStateManager.translate(0,0,0);
-            GlStateManager.rotate(45f,0,1,0);
-            GlStateManager.translate(0,0,1.0);
-            GlStateManager.enableAlpha();
-            GlStateManager.enableBlend();
-            GlStateManager.enableLighting();
-            for(int j=0;j<te.oregold && j<4;j++)
-            {
-                //Minecraft.getMinecraft().getRenderManager().doRenderEntity(GOLD,0,0,0,0f,0f,false);
-                Minecraft.getMinecraft().getRenderItem().renderItem(new ItemStack(Blocks.GOLD_ORE), ItemCameraTransforms.TransformType.GROUND);
-                GlStateManager.translate(0,0.2,0);
-            }
-        }
-        GlStateManager.popMatrix();
-        {}
-        GlStateManager.pushMatrix();
-        {
-            GlStateManager.translate(x,y,z);
-            GlStateManager.translate(0,0,0);
-            GlStateManager.rotate(45f,0,1,0);
-            GlStateManager.translate(0.25,0,0.75);
-            GlStateManager.enableAlpha();
-            GlStateManager.enableBlend();
-            GlStateManager.enableLighting();
-            for(int j=4;j<te.oregold && j>=4;j++)
-            {
-                //Minecraft.getMinecraft().getRenderManager().doRenderEntity(GOLD,0,0,0,0f,0f,false);
-                Minecraft.getMinecraft().getRenderItem().renderItem(new ItemStack(Blocks.GOLD_ORE), ItemCameraTransforms.TransformType.GROUND);
-                GlStateManager.translate(0,0.2,0);
+                GlStateManager.rotate(30f + j*50,0,1,0);
             }
         }
         GlStateManager.popMatrix();


### PR DESCRIPTION
This refactors the bloomery tile entity to use a list of ItemStacks instead of hardcoded ints.
For now it still only accepts iron and gold ores.

Also the rendering of the bloomery is a tad bit changed, such that each ore block is rotated a bit.
 
This should help on the way to fix #1